### PR TITLE
force index nod_own_dep_id_idx

### DIFF
--- a/java/src/main/java/edu/caltech/vao/vospace/meta/MySQLMetaStore.java
+++ b/java/src/main/java/edu/caltech/vao/vospace/meta/MySQLMetaStore.java
@@ -606,7 +606,7 @@ public class MySQLMetaStore implements MetaStore {
      * Get the direct children of the specified container node
      */
     public String[] getChildren(String identifier) throws SQLException, VOSpaceException {
-        String query = "select identifier from nodes where " +
+        String query = "select identifier from nodes force index (nod_own_dep_id_idx) where " +
                 " owner = '" + getOwnerFromId(identifier) + "'" +
                 " and depth = " + (getIdDepth(identifier) + 1)
                 + " and identifier like '" + escapeId(identifier) + "/%'";
@@ -664,7 +664,7 @@ public class MySQLMetaStore implements MetaStore {
      * properties and addl_properties table in one single SQL query.
      */
     public ca.nrc.cadc.vos.Node[] getChildrenNodesJDOM2(String identifier) throws SQLException, VOSpaceException {
-        String nodesQuery= "select identifier, type from nodes where " +
+        String nodesQuery= "select identifier, type from nodes force index (nod_own_dep_id_idx) where " +
                 " owner = '" + getOwnerFromId(identifier) + "'" +
                 " and depth = " + (getIdDepth(identifier) + 1) +
                 " and identifier like '" + escapeId(identifier) + "/%'";


### PR DESCRIPTION
If index stats in the database goes out of whack the right index might
not be used. Specifically for the query:
select identifier, type from nodes
where  owner = 'ls_dr8' and depth = 4 and identifier like
'vos://datalab.noirlab!vospace/ls\_dr8/calib/wise/modelsky/%'

We want to make sure that the index on owner, depth and identifier is
used. Doing so the performace improvent is two orders of magnitude.
e.g.
select identifier, type from nodes force index (nod_own_dep_id_idx)
where  owner = 'ls_dr8' and depth = 4 and identifier like
'vos://datalab.noirlab!vospace/ls\_dr8/calib/wise/modelsky/%'